### PR TITLE
fix: readme urls now point to the correct resources

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,12 +3,12 @@
 
 Custom Modules ⚡ supercharges ⚡ your Botpress chatbot building experience by adding in-chat capabilities and by customizing the chatbot editor to your liking.
 
-This Github template is meant as the starting point for building Botpress Custom Modules. You can find a non-exhaustive use-case list [here](#how-do-i-do-xyz?) as well as lots of references below.
+This Github template is meant as the starting point for building Botpress Custom Modules. You can find a non-exhaustive use-case list [here](#how-do-i-do-xyz) as well as lots of references below.
 
 ## Quick Start 
 
 1. Click "Use this template" at the top of the Github repo or fork this repo.
-2. Make your changes in the code. See [How do I do XYZ?](#how-do-i-do-xyz?)
+2. Make your changes in the code. See [How do I do XYZ?](#how-do-i-do-xyz)
 3. To rename the package, change the folder name, the name field in [src/backend/index.ts](src/backend/index.ts) and the name field in [src/backend/index.ts](src/backend/index.ts)
 4. Build using ``npm run dockerBuild``. The build will be named "YOUR_PACKAGE_NAME.tgz" and be located in the root folder.
 5. Open Botpress.
@@ -22,13 +22,13 @@ This Github template is meant as the starting point for building Botpress Custom
 
 
 ## (Advanced) Where's Hot Reload?
-Botpress doesn't currently support hot reload for custom module development. If you want to make changes and check them often, we recommend you clone the main repo and follow the instructions found [here](https://botpress.com/docs/building-chatbots/developers/custom-modules#local-development-tips). Changes will be reflected upon restarting the botpress server.
+Botpress doesn't currently support hot reload for custom module development. If you want to make changes and check them often, we recommend you clone the main repo and follow the instructions found [here](https://v12.botpress.com/building-chatbots/developers/custom-modules#local-development-tips). Changes will be reflected upon restarting the botpress server.
 
 Generally speaking : 
 1) Clone the main repo. ``git clone https://github.com/botpress/botpress.git``
 2) run ``yarn && yarn build`` in the main repo path.
-3) follow ["Module Templates"](https://botpress.com/docs/building-chatbots/developers/custom-modules#module-templates)
-4) Follow ["Local Development Tips"](https://botpress.com/docs/building-chatbots/developers/custom-modules#local-development-tips)
+3) follow ["Module Templates"](https://v12.botpress.com/building-chatbots/developers/custom-modules#module-templates)
+4) Follow ["Local Development Tips"](https://v12.botpress.com/building-chatbots/developers/custom-modules#local-development-tips)
 5) Use the command ``yarn start`` to start the Botpress server.
 6) To see changes, cancel the previous command, and use it again to restart the Botpress server and refresh your browser.
 
@@ -38,8 +38,8 @@ Here is a non-exhaustive list of things you can do with custom modules.
 
 - To add Hooks / middleware : read [this](src/hooks/README.md)
 - To add reusible code / actions : read [this](src/actions/README.md)
-- To add new skills to the flow editor like a datepicker : inject them [here](src/backend/index.ts) - docs [here](https://botpress.com/docs/building-chatbots/developers/custom-modules#skills)  
-- To create bot templates for creating new bots : add them [here](src/bot-templates/) - docs [here](https://botpress.com/docs/building-chatbots/developers/custom-modules#bottemplates)
+- To add new skills to the flow editor like a datepicker : inject them [here](src/backend/index.ts) - docs [here](https://v12.botpress.com/building-chatbots/developers/custom-modules#skills)  
+- To create bot templates for creating new bots : add them [here](src/bot-templates/) - docs [here](https://v12.botpress.com/building-chatbots/developers/custom-modules#bottemplates)
 - To create content types to be sent to your users : add them [here](src/views/lite/)
 - To create a navigation page within botpress : add them [here](src/views/full/index.jsx)
 
@@ -50,7 +50,7 @@ Pro tip :
 The bot making experience is smoother than the custom module building experience. If you can, make your changes in a Botpress Bot, then migrate the changes to your custom module code. 
 
 ### Documentation
-[Botpress Official Docs](https://botpress.com/docs/building-chatbots/developers/custom-modules)
+[Botpress Official Docs](https://v12.botpress.com/building-chatbots/developers/custom-modules)
 
 ### Unofficial Video Series
 1) [Module Structure](https://share.descript.com/view/F7HWNQVbpEX)

--- a/src/actions/README.md
+++ b/src/actions/README.md
@@ -5,4 +5,4 @@ They will overwrite existing files only if they haven't been edited manually.
 
 Actions added this way will be available on the flow editor using `starter-module/your-action-name`
 
-Check the documentation for more information about [Actions](https://botpress.com/docs/build/code#actions)
+Check the documentation for more information about [Actions](https://v12.botpress.com/build/code#actions)

--- a/src/hooks/README.md
+++ b/src/hooks/README.md
@@ -3,4 +3,4 @@
 Every time the server is started, Hooks that you put in this folder will be copied in the `data/global/hooks/starter-module/HOOK_TYPE/` folder.
 They will overwrite existing files only if they haven't been edited manually.
 
-Check the documentation for more information about [Hooks](https://botpress.com/docs/building-chatbots/developers/hooks)
+Check the documentation for more information about [Hooks](https://v12.botpress.com/building-chatbots/developers/hooks)


### PR DESCRIPTION
As someone who used this (Very helpful) resource recently, I hope this small contribution helps others who would also benefit. 

Currently, many URLs in the readme files do not point to the correct resources.

This PR addresses that.

1. Fixes the broken anchor links to the README itself
2. The URLs that moved over to the v12 botpress documentation site are now updated in all README files.